### PR TITLE
DOC: Miscellaneous doc improvements

### DIFF
--- a/citations/index.md
+++ b/citations/index.md
@@ -10,7 +10,7 @@ How to cite SlicerDMRI in publications
 * How to cite the [Slicer platform](http://wiki.slicer.org/slicerWiki/index.php/CitingSlicer)
 * An example of how to cite SlicerDMRI (modify the sentence according to your use case):
 
-    "We performed diffusion MRI tractography and/or analysis and/or visualization in 3D Slicer (www.slicer.org) via the SlicerDMRI project (http://dmri.slicer.org) (Zhang et al. 2020; Norton et al. 2017)."
+    "We performed diffusion MRI tractography and/or analysis and/or visualization in 3D Slicer (https://www.slicer.org/) via the SlicerDMRI project (http://dmri.slicer.org) (Zhang et al. 2020; Norton et al. 2017)."
     
     - [Fan Zhang, Thomas Noh, Parikshit Juvekar, Sarah F Frisken, Laura Rigolo, Isaiah Norton, Tina Kapur, Sonia Pujol, William Wells III, Alex Yarmarkovich, Gordon Kindlmann, Demian Wassermann, Raul San Jose Estepar, Yogesh Rathi, Ron Kikinis, Hans J Johnson, Carl-Fredrik Westin, Steve Pieper, Alexandra J Golby, Lauren J O'Donnell. SlicerDMRI: Diffusion MRI and Tractography Research Software for Brain Cancer Surgery Planning and Visualization. JCO Clinical Cancer Informatics 4, e299-309, 2020.](https://ascopubs.org/doi/full/10.1200/CCI.19.00141)
     

--- a/citations/index.md
+++ b/citations/index.md
@@ -7,7 +7,7 @@ order: 2
 
 How to cite SlicerDMRI in publications
 --------------------------------------
-* How to cite the [Slicer platform](http://wiki.slicer.org/slicerWiki/index.php/CitingSlicer)
+* How to cite the [Slicer platform](https://slicer.readthedocs.io/en/latest/user_guide/about.html#how-to-cite)
 * An example of how to cite SlicerDMRI (modify the sentence according to your use case):
 
     "We performed diffusion MRI tractography and/or analysis and/or visualization in 3D Slicer (https://www.slicer.org/) via the SlicerDMRI project (http://dmri.slicer.org) (Zhang et al. 2020; Norton et al. 2017)."

--- a/citations/index.md
+++ b/citations/index.md
@@ -14,7 +14,7 @@ How to cite SlicerDMRI in publications
     
     - [Fan Zhang, Thomas Noh, Parikshit Juvekar, Sarah F Frisken, Laura Rigolo, Isaiah Norton, Tina Kapur, Sonia Pujol, William Wells III, Alex Yarmarkovich, Gordon Kindlmann, Demian Wassermann, Raul San Jose Estepar, Yogesh Rathi, Ron Kikinis, Hans J Johnson, Carl-Fredrik Westin, Steve Pieper, Alexandra J Golby, Lauren J O'Donnell. SlicerDMRI: Diffusion MRI and Tractography Research Software for Brain Cancer Surgery Planning and Visualization. JCO Clinical Cancer Informatics 4, e299-309, 2020.](https://ascopubs.org/doi/full/10.1200/CCI.19.00141)
     
-    - [Isaiah Norton, Walid Ibn Essayed, Fan Zhang, Sonia Pujol, Alex Yarmarkovich, Alexandra J. Golby, Gordon Kindlmann, Demian Wassermann, Raul San Jose Estepar, Yogesh Rathi, Steve Pieper, Ron Kikinis, Hans J. Johnson, Carl-Fredrik Westin and Lauren J. O'Donnell. SlicerDMRI: Open Source Diffusion MRI Software for Brain Cancer Research. Cancer Research 77(21), e101-e103, 2017.](http://cancerres.aacrjournals.org/content/77/21/e101)
+    - [Isaiah Norton, Walid Ibn Essayed, Fan Zhang, Sonia Pujol, Alex Yarmarkovich, Alexandra J. Golby, Gordon Kindlmann, Demian Wassermann, Raul San Jose Estepar, Yogesh Rathi, Steve Pieper, Ron Kikinis, Hans J. Johnson, Carl-Fredrik Westin and Lauren J. O'Donnell. SlicerDMRI: Open Source Diffusion MRI Software for Brain Cancer Research. Cancer Research 77(21), e101-e103, 2017.](https://aacrjournals.org/cancerres/article/77/21/e101/662618/)
 
 * An example of how to cite whitematteranalysis and the ORG atlas (modify the sentence according to your use case):
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ After reviewing the material below, for usage questions please visit the [Slicer
 
 General Slicer guide
 ---------------------
-* [Slicer training](http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Training)
+* [Slicer training](https://www.slicer.org/w/index.php/Documentation/Nightly/Training)
 
 Tutorials and sample data
 ---------------------
@@ -28,13 +28,13 @@ Tutorials and sample data
 
 Individual Slicer module documentation pages
 ---------------------
-* [Slicer nightly documentation of Diffusion MRI modules](http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly#Modules_by_category_Diffusion)
+* [Slicer nightly documentation of Diffusion MRI modules](https://slicer.readthedocs.io/en/latest/user_guide/modules/index.html#diffusion)
 
 For developers
 ---------------------
 * [Source code of SlicerDMRI and whitematteranalysis](https://github.com/SlicerDMRI)
 * [DICOM Tractography Connectathon at RSNA 2017](https://qiicr.gitbooks.io/dicom4qi/content/instructions/tractography-results-dicom-tr.html)
-* [Python code to access tensor data from a DTI volume](https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/ScriptRepository#Access_values_in_a_DTI_tensor_volume)
+* [Python code to access tensor data from a DTI volume](https://slicer.readthedocs.io/en/latest/developer_guide/script_repository/volumes.html#access-values-in-a-dti-tensor-volume)
 
 * Please consider adding a "star" to these GitHub repositories:
     * [https://github.com/SlicerDMRI/SlicerDMRI](https://github.com/SlicerDMRI/SlicerDMRI)

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,8 +37,8 @@ For developers
 * [Python code to access tensor data from a DTI volume](https://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/ScriptRepository#Access_values_in_a_DTI_tensor_volume)
 
 * Please consider adding a "star" to these GitHub repositories:
-    * [http://github.com/SlicerDMRI/SlicerDMRI](http://github.com/SlicerDMRI/SlicerDMRI)
-    * [http://github.com/Slicer/slicer](http://github.com/slicer/slicer)
+    * [https://github.com/SlicerDMRI/SlicerDMRI](https://github.com/SlicerDMRI/SlicerDMRI)
+    * [https://github.com/Slicer/Slicer](https://github.com/Slicer/Slicer)
     ![While logged in to GitHub, please visit the two links above and select the "Star" button at the top right of the screen](../images/repo_star.png)
 
 Acknowledgments

--- a/download/index.md
+++ b/download/index.md
@@ -16,8 +16,8 @@ Then, install the SlicerDMRI extension using the Slicer extension manager. *Plea
 
 The source code for Slicer and SlicerDMRI is available from GitHub:
 
-  - https://github.com/SlicerDMRI/SlicerDMRI
-  - https://github.com/Slicer/slicer
+  - [https://github.com/SlicerDMRI/SlicerDMRI](https://github.com/SlicerDMRI/SlicerDMRI)
+  - [https://github.com/Slicer/Slicer](https://github.com/SlicerDMRI/SlicerDMRI)
 
 Full documentation for the Extension Manager is available [here](https://slicer.readthedocs.io/en/latest/user_guide/extensions_manager.html).
 

--- a/download/index.md
+++ b/download/index.md
@@ -19,7 +19,7 @@ The source code for Slicer and SlicerDMRI is available from GitHub:
   - https://github.com/SlicerDMRI/SlicerDMRI
   - https://github.com/Slicer/slicer
 
-Full documentation for the Extension Manager is available [here](https://www.slicer.org/wiki/Documentation/Nightly/SlicerApplication/ExtensionsManager).
+Full documentation for the Extension Manager is available [here](https://slicer.readthedocs.io/en/latest/user_guide/extensions_manager.html).
 
 
 For any questions, please contact us on the [Slicer Discussion Forum](https://discourse.slicer.org/c/community/slicerdmri), or file an issue on GitHub.

--- a/download/index.md
+++ b/download/index.md
@@ -5,9 +5,9 @@ permalink: /download/
 order: 5
 ---
 
-SlicerDMRI is a [3D Slicer](http://www.slicer.org) extension.
+SlicerDMRI is a [3D Slicer](https://www.slicer.org/) extension.
 
-First, [download and install 3D Slicer](http://download.slicer.org/) for your platform (Mac, Windows, or Linux). 
+First, [download and install 3D Slicer](https://download.slicer.org/) for your platform (Mac, Windows, or Linux).
 
 Then, install the SlicerDMRI extension using the Slicer extension manager. *Please make sure to restart Slicer after installing the extension!*. 
 


### PR DESCRIPTION
- DOC: Prefer using https over http for web addresses
- DOC: Use Slicer's new documentation web addresses
- DOC: Add links to the source code repositories in download page
- DOC: Use current Cancer Research journal web address